### PR TITLE
IconImage: new IconSize Property

### DIFF
--- a/Iconize/FormsPlugin.Iconize.Droid/IconImageRenderer.cs
+++ b/Iconize/FormsPlugin.Iconize.Droid/IconImageRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Android.Widget;
 using FormsPlugin.Iconize;
 using FormsPlugin.Iconize.Droid;
 using Plugin.Iconize.Droid.Controls;
@@ -9,57 +10,59 @@ using Xamarin.Forms.Platform.Android;
 [assembly: ExportRenderer(typeof(IconImage), typeof(IconImageRenderer))]
 namespace FormsPlugin.Iconize.Droid
 {
-    /// <summary>
-    /// Defines the <see cref="IconImageRenderer" /> renderer.
-    /// </summary>
-    /// <seealso cref="Xamarin.Forms.Platform.Android.ImageRenderer" />
-    public class IconImageRenderer : ImageRenderer
-    {
-        /// <summary>
-        /// Raises the <see cref="E:ElementChanged" /> event.
-        /// </summary>
-        /// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
-        protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
-        {
-            base.OnElementChanged(e);
+	/// <summary>
+	/// Defines the <see cref="IconImageRenderer" /> renderer.
+	/// </summary>
+	/// <seealso cref="Xamarin.Forms.Platform.Android.ImageRenderer" />
+	public class IconImageRenderer : ImageRenderer
+	{
+		/// <summary>
+		/// Raises the <see cref="E:ElementChanged" /> event.
+		/// </summary>
+		/// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
+		protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
+		{
+			base.OnElementChanged(e);
 
-            if (Control == null || Element == null)
-                return;
+			if (Control == null || Element == null)
+				return;
 
-            UpdateImage();
-        }
+			UpdateImage();
+		}
 
-        /// <summary>
-        /// Called when [element property changed].
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
-        protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
-        {
-            base.OnElementPropertyChanged(sender, e);
+		/// <summary>
+		/// Called when [element property changed].
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
+		protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
 
-            if (Control == null || Element == null)
-                return;
+			if (Control == null || Element == null)
+				return;
 
-            switch (e.PropertyName)
-            {
-                case nameof(IconImage.Icon):
-                case nameof(IconImage.IconColor):
-                    UpdateImage();
-                    break;
-            }
-        }
+			switch (e.PropertyName)
+			{
+				case nameof(IconImage.Icon):
+				case nameof(IconImage.IconColor):
+				case nameof(IconImage.IconSize):
+					UpdateImage();
+					break;
+			}
+		}
 
-        /// <summary>
-        /// Updates the image.
-        /// </summary>
-        private void UpdateImage()
-        {
-            var iconImage = Element as IconImage;
-            var drawable = new IconDrawable(Context, Plugin.Iconize.Iconize.FindIconForKey(iconImage.Icon))
-                                     .Color(iconImage.IconColor.ToAndroid())
-                                     .SizeDp((Int32)Element.HeightRequest);
-            Control.SetImageDrawable(drawable);
-        }
-    }
+		/// <summary>
+		/// Updates the image.
+		/// </summary>
+		private void UpdateImage()
+		{
+			var iconImage = Element as IconImage;
+			var drawable = new IconDrawable(Context, Plugin.Iconize.Iconize.FindIconForKey(iconImage.Icon))
+									 .Color(iconImage.IconColor.ToAndroid())
+									 .SizeDp(iconImage.IconSize > 0 ? (Int32)iconImage.IconSize : (Int32)Element.HeightRequest);
+			Control.SetScaleType(iconImage.IconSize > 0 ? ImageView.ScaleType.Center : ImageView.ScaleType.FitCenter);
+			Control.SetImageDrawable(drawable);
+		}
+	}
 }

--- a/Iconize/FormsPlugin.Iconize.Droid/IconImageRenderer.cs
+++ b/Iconize/FormsPlugin.Iconize.Droid/IconImageRenderer.cs
@@ -10,59 +10,65 @@ using Xamarin.Forms.Platform.Android;
 [assembly: ExportRenderer(typeof(IconImage), typeof(IconImageRenderer))]
 namespace FormsPlugin.Iconize.Droid
 {
-	/// <summary>
-	/// Defines the <see cref="IconImageRenderer" /> renderer.
-	/// </summary>
-	/// <seealso cref="Xamarin.Forms.Platform.Android.ImageRenderer" />
-	public class IconImageRenderer : ImageRenderer
-	{
-		/// <summary>
-		/// Raises the <see cref="E:ElementChanged" /> event.
-		/// </summary>
-		/// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
-		protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
-		{
-			base.OnElementChanged(e);
+    /// <summary>
+    /// Defines the <see cref="IconImageRenderer" /> renderer.
+    /// </summary>
+    /// <seealso cref="Xamarin.Forms.Platform.Android.ImageRenderer" />
+    public class IconImageRenderer : ImageRenderer
+    {
+        /// <summary>
+        /// Raises the <see cref="E:ElementChanged" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
+        protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
+        {
+            base.OnElementChanged(e);
 
-			if (Control == null || Element == null)
-				return;
+            if (Control == null || Element == null)
+                return;
 
-			UpdateImage();
-		}
+            UpdateImage();
+        }
 
-		/// <summary>
-		/// Called when [element property changed].
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
-		protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
-		{
-			base.OnElementPropertyChanged(sender, e);
+        /// <summary>
+        /// Called when [element property changed].
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
+        protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged(sender, e);
 
-			if (Control == null || Element == null)
-				return;
+            if (Control == null || Element == null)
+                return;
 
-			switch (e.PropertyName)
-			{
-				case nameof(IconImage.Icon):
-				case nameof(IconImage.IconColor):
-				case nameof(IconImage.IconSize):
-					UpdateImage();
-					break;
-			}
-		}
+            switch (e.PropertyName)
+            {
+                case nameof(IconImage.Icon):
+                case nameof(IconImage.IconColor):
+                case nameof(IconImage.IconSize):
+                    UpdateImage();
+                    break;
+            }
+        }
 
-		/// <summary>
-		/// Updates the image.
-		/// </summary>
-		private void UpdateImage()
-		{
-			var iconImage = Element as IconImage;
-			var drawable = new IconDrawable(Context, Plugin.Iconize.Iconize.FindIconForKey(iconImage.Icon))
-									 .Color(iconImage.IconColor.ToAndroid())
-									 .SizeDp(iconImage.IconSize > 0 ? (Int32)iconImage.IconSize : (Int32)Element.HeightRequest);
-			Control.SetScaleType(iconImage.IconSize > 0 ? ImageView.ScaleType.Center : ImageView.ScaleType.FitCenter);
-			Control.SetImageDrawable(drawable);
-		}
-	}
+        /// <summary>
+        /// Updates the image.
+        /// </summary>
+        private void UpdateImage()
+        {
+            var iconImage = Element as IconImage;
+            var iconToDraw = Plugin.Iconize.Iconize.FindIconForKey(iconImage.Icon);
+            if (iconToDraw == null)
+            {
+                Control.SetImageResource(Android.Resource.Color.Transparent);
+                return;
+            }
+            var drawable = new IconDrawable(Context, iconToDraw)
+                                     .Color(iconImage.IconColor.ToAndroid())
+                                     .SizeDp(iconImage.IconSize > 0 ? (Int32)iconImage.IconSize : (Int32)Element.HeightRequest);
+            Control.SetScaleType(iconImage.IconSize > 0 ? ImageView.ScaleType.Center : ImageView.ScaleType.FitCenter);
+            Control.SetImageDrawable(drawable);
+        }
+    }
 }

--- a/Iconize/FormsPlugin.Iconize.iOS/IconImageRenderer.cs
+++ b/Iconize/FormsPlugin.Iconize.iOS/IconImageRenderer.cs
@@ -10,52 +10,67 @@ using Xamarin.Forms.Platform.iOS;
 [assembly: ExportRenderer(typeof(IconImage), typeof(IconImageRenderer))]
 namespace FormsPlugin.Iconize.iOS
 {
-    /// <summary>
-    /// Defines the <see cref="IconImageRenderer" /> renderer.
-    /// </summary>
-    /// <seealso cref="Xamarin.Forms.Platform.iOS.ImageRenderer" />
-    public class IconImageRenderer : ImageRenderer
-    {
-        /// <summary>
-        /// Raises the <see cref="E:ElementChanged" /> event.
-        /// </summary>
-        /// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
-        protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
-        {
-            base.OnElementChanged(e);
+	/// <summary>
+	/// Defines the <see cref="IconImageRenderer" /> renderer.
+	/// </summary>
+	/// <seealso cref="Xamarin.Forms.Platform.iOS.ImageRenderer" />
+	public class IconImageRenderer : ImageRenderer
+	{
+		/// <summary>
+		/// Raises the <see cref="E:ElementChanged" /> event.
+		/// </summary>
+		/// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
+		protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
+		{
+			base.OnElementChanged(e);
 
-            if (Control == null || Element == null)
-                return;
+			if (Control == null || Element == null)
+				return;
 
-            var iconImage = Element as IconImage;
-            Control.Image = Plugin.Iconize.Iconize.FindIconForKey(iconImage.Icon).ToUIImage((nfloat)Element.HeightRequest).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
-            Control.TintColor = iconImage.IconColor.ToUIColor();
-        }
+			this.UpdateImage(true);
+		}
 
-        /// <summary>
-        /// Called when [element property changed].
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
-        protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
-        {
-            base.OnElementPropertyChanged(sender, e);
+		/// <summary>
+		/// Called when [element property changed].
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
+		protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
 
-            if (Control == null || Element == null)
-                return;
+			if (Control == null || Element == null)
+				return;
 
-            var iconImage = Element as IconImage;
+			switch (e.PropertyName)
+			{
+				case nameof(IconImage.Icon):
+				case nameof(IconImage.IconSize):
+					this.UpdateImage(true);
+					break;
 
-            switch (e.PropertyName)
-            {
-                case nameof(IconImage.Icon):
-                    Control.Image = Plugin.Iconize.Iconize.FindIconForKey(iconImage.Icon).ToUIImage((nfloat)Element.HeightRequest).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
-                    break;
+				case nameof(IconImage.IconColor):
+					this.UpdateImage(false);
+					break;
+			}
+		}
 
-                case nameof(IconImage.IconColor):
-                    Control.TintColor = iconImage.IconColor.ToUIColor();
-                    break;
-            }
-        }
-    }
+		private void UpdateImage(bool shouldUpdateImage)
+		{
+			var iconImage = Element as IconImage;
+			if (shouldUpdateImage)
+			{
+				Control.ContentMode =
+					iconImage.IconSize > 0 ?
+						UIViewContentMode.Center :
+						UIViewContentMode.ScaleAspectFit;
+				Control.Image =
+					Plugin.Iconize.Iconize
+						.FindIconForKey(iconImage.Icon)
+						.ToUIImage(iconImage.IconSize > 0 ? (nfloat)iconImage.IconSize : (nfloat)Element.HeightRequest)
+						.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+			}
+			Control.TintColor = iconImage.IconColor.ToUIColor();
+		}
+	}
 }

--- a/Iconize/FormsPlugin.Iconize.iOS/IconImageRenderer.cs
+++ b/Iconize/FormsPlugin.Iconize.iOS/IconImageRenderer.cs
@@ -10,67 +10,73 @@ using Xamarin.Forms.Platform.iOS;
 [assembly: ExportRenderer(typeof(IconImage), typeof(IconImageRenderer))]
 namespace FormsPlugin.Iconize.iOS
 {
-	/// <summary>
-	/// Defines the <see cref="IconImageRenderer" /> renderer.
-	/// </summary>
-	/// <seealso cref="Xamarin.Forms.Platform.iOS.ImageRenderer" />
-	public class IconImageRenderer : ImageRenderer
-	{
-		/// <summary>
-		/// Raises the <see cref="E:ElementChanged" /> event.
-		/// </summary>
-		/// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
-		protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
-		{
-			base.OnElementChanged(e);
+    /// <summary>
+    /// Defines the <see cref="IconImageRenderer" /> renderer.
+    /// </summary>
+    /// <seealso cref="Xamarin.Forms.Platform.iOS.ImageRenderer" />
+    public class IconImageRenderer : ImageRenderer
+    {
+        /// <summary>
+        /// Raises the <see cref="E:ElementChanged" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="ElementChangedEventArgs{Image}" /> instance containing the event data.</param>
+        protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
+        {
+            base.OnElementChanged(e);
 
-			if (Control == null || Element == null)
-				return;
+            if (Control == null || Element == null)
+                return;
 
-			this.UpdateImage(true);
-		}
+            this.UpdateImage(true);
+        }
 
-		/// <summary>
-		/// Called when [element property changed].
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
-		protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
-		{
-			base.OnElementPropertyChanged(sender, e);
+        /// <summary>
+        /// Called when [element property changed].
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="PropertyChangedEventArgs" /> instance containing the event data.</param>
+        protected override void OnElementPropertyChanged(Object sender, PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged(sender, e);
 
-			if (Control == null || Element == null)
-				return;
+            if (Control == null || Element == null)
+                return;
 
-			switch (e.PropertyName)
-			{
-				case nameof(IconImage.Icon):
-				case nameof(IconImage.IconSize):
-					this.UpdateImage(true);
-					break;
+            switch (e.PropertyName)
+            {
+                case nameof(IconImage.Icon):
+                case nameof(IconImage.IconSize):
+                    this.UpdateImage(true);
+                    break;
 
-				case nameof(IconImage.IconColor):
-					this.UpdateImage(false);
-					break;
-			}
-		}
+                case nameof(IconImage.IconColor):
+                    this.UpdateImage(false);
+                    break;
+            }
+        }
 
-		private void UpdateImage(bool shouldUpdateImage)
-		{
-			var iconImage = Element as IconImage;
-			if (shouldUpdateImage)
-			{
-				Control.ContentMode =
-					iconImage.IconSize > 0 ?
-						UIViewContentMode.Center :
-						UIViewContentMode.ScaleAspectFit;
-				Control.Image =
-					Plugin.Iconize.Iconize
-						.FindIconForKey(iconImage.Icon)
-						.ToUIImage(iconImage.IconSize > 0 ? (nfloat)iconImage.IconSize : (nfloat)Element.HeightRequest)
-						.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
-			}
-			Control.TintColor = iconImage.IconColor.ToUIColor();
-		}
-	}
+        private void UpdateImage(bool shouldUpdateImage)
+        {
+            var iconImage = Element as IconImage;
+            if (shouldUpdateImage)
+            {
+                Control.ContentMode =
+                        iconImage.IconSize > 0 ?
+                            UIViewContentMode.Center :
+                            UIViewContentMode.ScaleAspectFit;
+
+                var iconToDraw = Plugin.Iconize.Iconize.FindIconForKey(iconImage.Icon);
+                if (iconToDraw == null)
+                {
+                    Control.Image = null;
+                    return;
+                }
+                Control.Image =
+                        iconToDraw
+                        .ToUIImage(iconImage.IconSize > 0 ? (nfloat)iconImage.IconSize : (nfloat)Element.HeightRequest)
+                        .ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+            }
+            Control.TintColor = iconImage.IconColor.ToUIColor();
+        }
+    }
 }

--- a/Iconize/FormsPlugin.Iconize/IconImage.cs
+++ b/Iconize/FormsPlugin.Iconize/IconImage.cs
@@ -3,44 +3,73 @@ using Xamarin.Forms;
 
 namespace FormsPlugin.Iconize
 {
-    /// <summary>
-    /// Defines the <see cref="IconImage" /> control.
-    /// </summary>
-    /// <seealso cref="Xamarin.Forms.Image" />
-    public class IconImage : Image
-    {
-        /// <summary>
-        /// Property definition for the <see cref="Icon" /> Property
-        /// </summary>
-        public static BindableProperty IconProperty = BindableProperty.Create(nameof(Icon), typeof(String), typeof(IconImage), String.Empty);
+	/// <summary>
+	/// Defines the <see cref="IconImage" /> control.
+	/// </summary>
+	/// <seealso cref="Xamarin.Forms.Image" />
+	public class IconImage : Image
+	{
+		#region Static Properties
 
-        /// <summary>
-        /// Property definition for the <see cref="IconColor" /> Property
-        /// </summary>
-        public static BindableProperty IconColorProperty = BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(IconImage), Color.Default);
+		/// <summary>
+		/// When the property <see cref="IconSize" /> is set to this value, the icon size will match the Image Size.
+		/// </summary>
+		public static double IconAutoSize { get { return -1.0; } }
 
-        /// <summary>
-        /// Gets or sets the icon.
-        /// </summary>
-        /// <value>
-        /// The icon.
-        /// </value>
-        public String Icon
-        {
-            get { return (String)GetValue(IconProperty); }
-            set { SetValue(IconProperty, value); }
-        }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the color of the icon.
-        /// </summary>
-        /// <value>
-        /// The color of the icon.
-        /// </value>
-        public Color IconColor
-        {
-            get { return (Color)GetValue(IconColorProperty); }
-            set { SetValue(IconColorProperty, value); }
-        }
-    }
+		#region Icon Property
+
+		/// <summary>
+		/// Property definition for the <see cref="Icon" /> Property
+		/// </summary>
+		public static readonly BindableProperty IconProperty = BindableProperty.Create(nameof(Icon), typeof(String), typeof(IconImage), String.Empty);
+
+		/// <summary>
+		/// Gets or sets the icon.
+		/// </summary>
+		/// <value>
+		/// The icon.
+		/// </value>
+		public String Icon
+		{
+			get { return (String)GetValue(IconProperty); }
+			set { SetValue(IconProperty, value); }
+		}
+
+		#endregion
+
+		#region IconColor Property
+
+		/// <summary>
+		/// Property definition for the <see cref="IconColor" /> Property
+		/// </summary>
+		public static BindableProperty IconColorProperty = BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(IconImage), Color.Default);
+
+		/// <summary>
+		/// Gets or sets the color of the icon.
+		/// </summary>
+		/// <value>
+		/// The color of the icon.
+		/// </value>
+		public Color IconColor
+		{
+			get { return (Color)GetValue(IconColorProperty); }
+			set { SetValue(IconColorProperty, value); }
+		}
+
+		#endregion
+
+		#region IconSize Property
+
+		public static readonly BindableProperty IconSizeProperty = BindableProperty.Create(nameof(IconSize), typeof(double), typeof(IconImage), IconImage.IconAutoSize);
+
+		public double IconSize
+		{
+			get { return (double)GetValue(IconSizeProperty); }
+			set { SetValue(IconSizeProperty, value); }
+		}
+
+		#endregion
+	}
 }

--- a/Iconize/FormsPlugin.Iconize/IconImage.cs
+++ b/Iconize/FormsPlugin.Iconize/IconImage.cs
@@ -3,73 +3,73 @@ using Xamarin.Forms;
 
 namespace FormsPlugin.Iconize
 {
-	/// <summary>
-	/// Defines the <see cref="IconImage" /> control.
-	/// </summary>
-	/// <seealso cref="Xamarin.Forms.Image" />
-	public class IconImage : Image
-	{
-		#region Static Properties
+    /// <summary>
+    /// Defines the <see cref="IconImage" /> control.
+    /// </summary>
+    /// <seealso cref="Xamarin.Forms.Image" />
+    public class IconImage : Image
+    {
+        #region Static Properties
 
-		/// <summary>
-		/// When the property <see cref="IconSize" /> is set to this value, the icon size will match the Image Size.
-		/// </summary>
-		public static double IconAutoSize { get { return -1.0; } }
+        /// <summary>
+        /// When the property <see cref="IconSize" /> is set to this value, the icon size will match the Image Size.
+        /// </summary>
+        public static double IconAutoSize { get { return -1.0; } }
 
-		#endregion
+        #endregion
 
-		#region Icon Property
+        #region Icon Property
 
-		/// <summary>
-		/// Property definition for the <see cref="Icon" /> Property
-		/// </summary>
-		public static readonly BindableProperty IconProperty = BindableProperty.Create(nameof(Icon), typeof(String), typeof(IconImage), String.Empty);
+        /// <summary>
+        /// Property definition for the <see cref="Icon" /> Property
+        /// </summary>
+        public static readonly BindableProperty IconProperty = BindableProperty.Create(nameof(Icon), typeof(String), typeof(IconImage), String.Empty);
 
-		/// <summary>
-		/// Gets or sets the icon.
-		/// </summary>
-		/// <value>
-		/// The icon.
-		/// </value>
-		public String Icon
-		{
-			get { return (String)GetValue(IconProperty); }
-			set { SetValue(IconProperty, value); }
-		}
+        /// <summary>
+        /// Gets or sets the icon.
+        /// </summary>
+        /// <value>
+        /// The icon.
+        /// </value>
+        public String Icon
+        {
+            get { return (String)GetValue(IconProperty); }
+            set { SetValue(IconProperty, value); }
+        }
 
-		#endregion
+        #endregion
 
-		#region IconColor Property
+        #region IconColor Property
 
-		/// <summary>
-		/// Property definition for the <see cref="IconColor" /> Property
-		/// </summary>
-		public static BindableProperty IconColorProperty = BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(IconImage), Color.Default);
+        /// <summary>
+        /// Property definition for the <see cref="IconColor" /> Property
+        /// </summary>
+        public static BindableProperty IconColorProperty = BindableProperty.Create(nameof(IconColor), typeof(Color), typeof(IconImage), Color.Default);
 
-		/// <summary>
-		/// Gets or sets the color of the icon.
-		/// </summary>
-		/// <value>
-		/// The color of the icon.
-		/// </value>
-		public Color IconColor
-		{
-			get { return (Color)GetValue(IconColorProperty); }
-			set { SetValue(IconColorProperty, value); }
-		}
+        /// <summary>
+        /// Gets or sets the color of the icon.
+        /// </summary>
+        /// <value>
+        /// The color of the icon.
+        /// </value>
+        public Color IconColor
+        {
+            get { return (Color)GetValue(IconColorProperty); }
+            set { SetValue(IconColorProperty, value); }
+        }
 
-		#endregion
+        #endregion
 
-		#region IconSize Property
+        #region IconSize Property
 
-		public static readonly BindableProperty IconSizeProperty = BindableProperty.Create(nameof(IconSize), typeof(double), typeof(IconImage), IconImage.IconAutoSize);
+        public static readonly BindableProperty IconSizeProperty = BindableProperty.Create(nameof(IconSize), typeof(double), typeof(IconImage), IconImage.IconAutoSize);
 
-		public double IconSize
-		{
-			get { return (double)GetValue(IconSizeProperty); }
-			set { SetValue(IconSizeProperty, value); }
-		}
+        public double IconSize
+        {
+            get { return (double)GetValue(IconSizeProperty); }
+            set { SetValue(IconSizeProperty, value); }
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Iconize/Plugin.Iconize/Iconize.cs
+++ b/Iconize/Plugin.Iconize/Iconize.cs
@@ -98,6 +98,7 @@ namespace Plugin.Iconize
         /// <returns>The icon, or null if no icon matches the key</returns>
         public static IIcon FindIconForKey(String iconKey)
         {
+            if (string.IsNullOrEmpty(iconKey)) { return null; }
             return Modules.FirstOrDefault(x => x.Keys.Contains(iconKey))?.GetIcon(iconKey);
         }
     }

--- a/Iconize/Samples/Iconize.FormsSample/Page1.xaml
+++ b/Iconize/Samples/Iconize.FormsSample/Page1.xaml
@@ -1,29 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:iconize="clr-namespace:FormsPlugin.Iconize;assembly=FormsPlugin.Iconize"
-             x:Class="Iconize.FormsSample.Page1"
-             Title="{Binding FontFamily}">
-
-  <ContentPage.ToolbarItems>
-    <iconize:IconToolbarItem Command="{Binding MenuItemClick}" Icon="fa-500px" />
-    <iconize:IconToolbarItem Command="{Binding MenuItemClick}" Icon="fa-500px" IconColor="Red" />
-    <iconize:IconToolbarItem Command="{Binding MenuItemClick}" Icon="fa-500px" IsVisible="{Binding VisibleTest}" />
-  </ContentPage.ToolbarItems>
-
-  <ListView CachingStrategy="RecycleElement" ItemsSource="{Binding Characters}">
-    <ListView.ItemTemplate>
-      <DataTemplate>
-        <ViewCell>
-          <StackLayout Orientation="Horizontal">
-            <iconize:IconImage HeightRequest="20" Icon="{Binding Key}" IconColor="Blue" WidthRequest="20" />
-            <iconize:IconButton FontSize="20" Text="{Binding Key, StringFormat='{}{{{0}}}'}" TextColor="Red" WidthRequest="48" />
-            <iconize:IconLabel FontSize="20" Text="{Binding Key, StringFormat='{}{{{0}}}'}" TextColor="Green" VerticalTextAlignment="Center" />
-            <Label Text="{Binding Key}" VerticalTextAlignment="Center" />
-          </StackLayout>
-        </ViewCell>
-      </DataTemplate>
-    </ListView.ItemTemplate>
-  </ListView>
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:iconize="clr-namespace:FormsPlugin.Iconize;assembly=FormsPlugin.Iconize" x:Class="Iconize.FormsSample.Page1" Title="{Binding FontFamily}">
+	<ContentPage.ToolbarItems>
+		<iconize:IconToolbarItem Command="{Binding MenuItemClick}" Icon="fa-500px" />
+		<iconize:IconToolbarItem Command="{Binding MenuItemClick}" Icon="fa-500px" IconColor="Red" />
+		<iconize:IconToolbarItem Command="{Binding MenuItemClick}" Icon="fa-500px" IsVisible="{Binding VisibleTest}" />
+	</ContentPage.ToolbarItems>
+	<ListView CachingStrategy="RecycleElement" ItemsSource="{Binding Characters}">
+		<ListView.ItemTemplate>
+			<DataTemplate>
+				<ViewCell>
+					<StackLayout Orientation="Horizontal">
+						<iconize:IconImage HeightRequest="20" Icon="{Binding Key}" IconColor="Blue" WidthRequest="20" />
+						<iconize:IconImage HeightRequest="20" Icon="{Binding Key}" BackgroundColor="Blue" IconColor="Yellow" WidthRequest="20" IconSize="10" />
+						<iconize:IconButton FontSize="20" Text="{Binding Key, StringFormat='{}{{{0}}}'}" TextColor="Red" WidthRequest="48" />
+						<iconize:IconLabel FontSize="20" Text="{Binding Key, StringFormat='{}{{{0}}}'}" TextColor="Green" VerticalTextAlignment="Center" />
+						<Label Text="{Binding Key}" VerticalTextAlignment="Center" />
+					</StackLayout>
+				</ViewCell>
+			</DataTemplate>
+		</ListView.ItemTemplate>
+	</ListView>
 </ContentPage>


### PR DESCRIPTION
Hi!
First of all let me say great project!

I've played with your components a little and I thought that the IconImage was missing a way to let the user set the Icon size.
I use this little customization to have an Image with a placeholder icon, and then replace it with a real image when the user wants to (example: "add photo", I use as placeholder the fa-camera, a tapgesture recognizer for the action and then use the IconImage object to display the shot).
Let me know if this PR meets your standards.

Cheers,
Riccardo.

PS I tried to fix the code formatting, but I lost the battle with Xamarin Studio 6. 