### PR TITLE
Fixed CGSize exception

### DIFF
--- a/Iconize/Plugin.Iconize.iOS/IconizeExtensions.cs
+++ b/Iconize/Plugin.Iconize.iOS/IconizeExtensions.cs
@@ -65,7 +65,7 @@ namespace Plugin.Iconize.iOS
                 ForegroundColorFromContext = true
             });
 
-            var boundSize = attributedString.GetBoundingRect(new CGSize(10000, 10000), NSStringDrawingOptions.UsesLineFragmentOrigin, null).Size;
+            var boundSize = attributedString.GetBoundingRect(new CGSize(10000f, 10000f), NSStringDrawingOptions.UsesLineFragmentOrigin, null).Size;
 
             UIGraphics.BeginImageContextWithOptions(boundSize, false, 0f);
             attributedString.DrawString(new CGRect(0, 0, boundSize.Width, boundSize.Height));


### PR DESCRIPTION
MTOUCH: error MT2002: Failed to resolve System.Void CoreGraphics.CGSize::.ctor(System.Single,System.Single) on iOS