### PR TITLE
Fix Android Xamarin Forms renderers memory leak

### DIFF
--- a/Iconize/FormsPlugin.Iconize.Droid/IconButtonRenderer.cs
+++ b/Iconize/FormsPlugin.Iconize.Droid/IconButtonRenderer.cs
@@ -17,17 +17,23 @@ namespace FormsPlugin.Iconize.Droid
     public class IconButtonRenderer : ButtonRenderer
     {
         /// <summary>
-        /// Disposes the specified disposing.
+        /// Called when [attached to window].
         /// </summary>
-        /// <param name="disposing">if set to <c>true</c> [disposing].</param>
-        protected override void Dispose(Boolean disposing)
+        protected override void OnAttachedToWindow()
         {
-            if (Control != null)
-            {
-                Control.TextChanged -= OnTextChanged;
-            }
+            base.OnAttachedToWindow();
 
-            base.Dispose(disposing);
+            Control.TextChanged += OnTextChanged;
+        }
+
+        /// <summary>
+        /// Called when [detached from window].
+        /// </summary>
+        protected override void OnDetachedFromWindow()
+        {
+            Control.TextChanged -= OnTextChanged;
+
+            base.OnDetachedFromWindow();
         }
 
         /// <summary>
@@ -43,7 +49,6 @@ namespace FormsPlugin.Iconize.Droid
 
             Control.SetAllCaps(false);
             UpdateText();
-            Control.TextChanged += OnTextChanged;
         }
 
         /// <summary>

--- a/Iconize/FormsPlugin.Iconize.Droid/IconLabelRenderer.cs
+++ b/Iconize/FormsPlugin.Iconize.Droid/IconLabelRenderer.cs
@@ -16,17 +16,23 @@ namespace FormsPlugin.Iconize.Droid
     public class IconLabelRenderer : LabelRenderer
     {
         /// <summary>
-        /// Disposes the specified disposing.
+        /// Called when [attached to window].
         /// </summary>
-        /// <param name="disposing">if set to <c>true</c> [disposing].</param>
-        protected override void Dispose(Boolean disposing)
+        protected override void OnAttachedToWindow()
         {
-            if (Control != null)
-            {
-                Control.TextChanged -= OnTextChanged;
-            }
+            base.OnAttachedToWindow();
 
-            base.Dispose(disposing);
+            Control.TextChanged += OnTextChanged;
+        }
+
+        /// <summary>
+        /// Called when [detached from window].
+        /// </summary>
+        protected override void OnDetachedFromWindow()
+        {
+            Control.TextChanged -= OnTextChanged;
+
+            base.OnDetachedFromWindow();
         }
 
         /// <summary>
@@ -41,7 +47,6 @@ namespace FormsPlugin.Iconize.Droid
                 return;
 
             UpdateText();
-            Control.TextChanged += OnTextChanged;
         }
 
         /// <summary>


### PR DESCRIPTION
Hi, 

On Android, IconLabel and IconButton renderers events handlers cause a memory leak.
After several navigation this cause application to hang.

With the Xamarin Profiler, I found that the issue was caused by Iconize.
![memoryleak](https://cloud.githubusercontent.com/assets/1446221/19121472/ed0e47d2-8b26-11e6-9201-0446d88b212c.PNG)

Unsubscribing event in OnDetachedFromWindow solve the issue.