### PR TITLE
Add a null check to IconTabbedPageRenderer

### DIFF
--- a/Iconize/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
+++ b/Iconize/FormsPlugin.Iconize.Droid/IconTabbedPageRenderer.cs
@@ -41,7 +41,9 @@ namespace FormsPlugin.Iconize.Droid
             {
                 foreach (var page in e.NewElement.Children)
                 {
-                    _icons.Add(page.Icon.File);
+                    if (page.Icon != null)
+                        _icons.Add(page.Icon.File);
+
                     page.Icon = null;
                 }
             }


### PR DESCRIPTION
This pull request adds a null check to IconTabbedPageRenderer.

This null check prevents the application from crashing if you navigate to an IconTabbedPage with children ContentPage element that have a NULL icon.